### PR TITLE
pre-alpha: Revert SSR web component

### DIFF
--- a/src/lib/components/Descope.tsx
+++ b/src/lib/components/Descope.tsx
@@ -1,36 +1,18 @@
+import '@descope/web-component';
 import React, {
-	lazy,
-	Suspense,
 	useCallback,
 	useEffect,
 	useImperativeHandle,
-	useState
+	useRef
 } from 'react';
 import AuthContext from '../hooks/authContext';
 import { DescopeProps } from '../types';
 
-// web-component code uses browser API, but can be used in SSR apps, hence the lazy loading
-const DescopeWC = lazy(async () => {
-	await import('@descope/web-component');
-	return {
-		default: ({ projectId, flowId, baseUrl, innerRef, tenant, theme }) => (
-			<descope-wc
-				project-id={projectId}
-				flow-id={flowId}
-				base-url={baseUrl}
-				ref={innerRef}
-				tenant={tenant}
-				theme={theme}
-			/>
-		)
-	};
-});
-
 const Descope = React.forwardRef<HTMLElement, DescopeProps>(
 	({ flowId, onSuccess, onError, tenant, theme }, ref) => {
-		const [innerRef, setInnerRef] = useState(null);
+		const innerRef = useRef<HTMLInputElement>();
 
-		useImperativeHandle(ref, () => innerRef);
+		useImperativeHandle(ref, () => innerRef.current);
 
 		const { projectId, baseUrl, setUser, setSessionToken } =
 			React.useContext(AuthContext);
@@ -48,7 +30,7 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
 		);
 
 		useEffect(() => {
-			const ele = innerRef;
+			const ele = innerRef.current;
 			ele?.addEventListener('success', handleSuccess);
 			if (onError) ele?.addEventListener('error', onError);
 
@@ -60,16 +42,14 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
 		}, [innerRef, onError, handleSuccess]);
 
 		return (
-			<Suspense>
-				<DescopeWC
-					projectId={projectId}
-					flowId={flowId}
-					baseUrl={baseUrl}
-					innerRef={setInnerRef}
-					tenant={tenant}
-					theme={theme}
-				/>
-			</Suspense>
+			<descope-wc
+				project-id={projectId}
+				flow-id={flowId}
+				base-url={baseUrl}
+				ref={innerRef}
+				tenant={tenant}
+				theme={theme}
+			/>
 		);
 	}
 );

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-node-access */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import createSdk from '@descope/web-js-sdk';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../../src/app/App';
@@ -18,8 +18,9 @@ jest.mock('@descope/web-js-sdk', () => {
 	return () => sdk;
 });
 
-const renderWithRouter = (ui: React.ReactElement) =>
+const renderWithRouter = (ui: React.ReactElement) => {
 	render(<MemoryRouter>{ui}</MemoryRouter>);
+};
 
 const { logout, onSessionTokenChange, onUserChange } = createSdk({
 	projectId: ''
@@ -32,19 +33,14 @@ describe('App', () => {
 		(onUserChange as jest.Mock).mockImplementation();
 	});
 
-	it('should get user on success', async () => {
+	it('should get user on success', () => {
 		renderWithRouter(
 			<AuthProvider projectId="p1">
 				<App />
 			</AuthProvider>
 		);
-
 		const loginButton = document.querySelector('#login-button');
 		fireEvent.click(loginButton);
-
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
 
 		// mock success
 		fireEvent(

--- a/test/components/DefaultFlows.test.tsx
+++ b/test/components/DefaultFlows.test.tsx
@@ -1,7 +1,4 @@
-/* eslint-disable testing-library/no-node-access */ import {
-	render,
-	waitFor
-} from '@testing-library/react';
+/* eslint-disable testing-library/no-node-access */ import { render } from '@testing-library/react';
 import React from 'react';
 import { SignInFlow, SignUpFlow, SignUpOrInFlow } from '../../src/lib';
 import AuthProvider from '../../src/lib/components/AuthProvider';
@@ -17,16 +14,13 @@ jest.mock('@descope/web-js-sdk', () => {
 	return () => sdk;
 });
 
-const renderWithProvider = (ui: React.ReactElement, projectId: string) =>
-	// eslint-disable-next-line testing-library/no-unnecessary-act
+const renderWithProvider = (ui: React.ReactElement, projectId: string) => {
 	render(<AuthProvider projectId={projectId}>{ui}</AuthProvider>);
+};
 
 describe('Default Flows', () => {
-	it('should render Sign In with the correct props and flow', async () => {
+	it('should render Sign In with the correct props and flow', () => {
 		renderWithProvider(<SignInFlow />, 'proj1');
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
 		expect(document.querySelector('descope-wc')).toHaveAttribute(
 			'project-id',
 			'proj1'
@@ -37,11 +31,8 @@ describe('Default Flows', () => {
 		);
 	});
 
-	it('should render Sign Up with the correct props and flow', async () => {
+	it('should render Sign Up with the correct props and flow', () => {
 		renderWithProvider(<SignUpFlow />, 'proj1');
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
 		expect(document.querySelector('descope-wc')).toHaveAttribute(
 			'project-id',
 			'proj1'
@@ -52,11 +43,8 @@ describe('Default Flows', () => {
 		);
 	});
 
-	it('should render Sign Up Or In In with the correct props and flow', async () => {
+	it('should render Sign Up Or In In with the correct props and flow', () => {
 		renderWithProvider(<SignUpOrInFlow />, 'proj1');
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
 		expect(document.querySelector('descope-wc')).toHaveAttribute(
 			'project-id',
 			'proj1'

--- a/test/components/Descope.test.tsx
+++ b/test/components/Descope.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-node-access */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import createSdk from '@descope/web-js-sdk';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import AuthProvider from '../../src/lib/components/AuthProvider';
 import Descope from '../../src/lib/components/Descope';
@@ -20,20 +20,17 @@ const renderWithProvider = (
 	ui: React.ReactElement,
 	projectId: string = 'project1',
 	baseUrl?: string
-) =>
+) => {
 	render(
 		<AuthProvider projectId={projectId} baseUrl={baseUrl}>
 			{ui}
 		</AuthProvider>
 	);
+};
 
 describe('Descope', () => {
-	it('should render the WC with the correct props', async () => {
+	it('should render the WC with the correct props', () => {
 		renderWithProvider(<Descope flowId="flow1" />, 'proj1', 'url1');
-
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
 
 		expect(document.querySelector('descope-wc')).toHaveAttribute(
 			'project-id',
@@ -49,20 +46,17 @@ describe('Descope', () => {
 		);
 	});
 
-	it('should register to the error event when received an onError cb', async () => {
+	it('should register to the error event when received an onError cb', () => {
 		const onError = jest.fn();
 		renderWithProvider(<Descope flowId="flow-1" onError={onError} />);
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
 		fireEvent(document.querySelector('descope-wc'), new CustomEvent('error'));
 
 		expect(onError).toHaveBeenCalled();
 	});
 
-	it('should register to the success event when received an onSuccess cb', async () => {
+	it('should register to the success event when received an onSuccess cb', () => {
 		const onSuccess = jest.fn();
-		await renderWithProvider(<Descope flowId="flow-1" onSuccess={onSuccess} />);
+		renderWithProvider(<Descope flowId="flow-1" onSuccess={onSuccess} />);
 		fireEvent(
 			document.querySelector('descope-wc'),
 			new CustomEvent('success', {
@@ -73,21 +67,15 @@ describe('Descope', () => {
 		expect(onSuccess).toHaveBeenCalled();
 	});
 
-	it('should pass the ref to the wc element', async () => {
+	it('should pass the ref to the wc element', () => {
 		const ref = jest.fn();
 		renderWithProvider(<Descope flowId="flow-1" ref={ref} />);
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
 		expect(ref).toHaveBeenCalledWith(document.querySelector('descope-wc'));
 	});
 
-	it('should add descope headers to request', async () => {
+	it('should add descope headers to request', () => {
 		const ref = jest.fn();
 		renderWithProvider(<Descope flowId="flow-1" ref={ref} />);
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
 		const returnedConf = (
 			createSdk as jest.Mock
 		).mock.calls[0][0].hooks.beforeRequest({


### PR DESCRIPTION
Reverts descope/react-sdk#99

this seems to cause troubles for our b2b sample app (both when it runs locally and on vercel)
let's revert, so we will have a good latest, and then continue to debug this separately  

![image](https://user-images.githubusercontent.com/10514677/205113980-5c7bd1f9-4d76-4ce7-b2d5-60524e721a58.png)

```
react-dom.development.js:20085 The above error occurred in one of your React components:

    at Lazy
    at Suspense
    at http://localhost:3000/static/js/bundle.js:355792:15
    at div
    at http://localhost:3000/static/js/bundle.js:43678:66
    at http://localhost:3000/static/js/bundle.js:21114:25
    at SSOConfig (http://localhost:3000/static/js/bundle.js:6628:88)
    at Route (http://localhost:3000/static/js/bundle.js:336577:29)
    at Switch (http://localhost:3000/static/js/bundle.js:336746:29)
    at div
    at http://localhost:3000/static/js/bundle.js:43678:66
    at div
    at http://localhost:3000/static/js/bundle.js:43678:66
    at div
    at http://localhost:3000/static/js/bundle.js:43678:66
    at Dashboard (http://localhost:3000/static/js/bundle.js:5769:8)
    at Route (http://localhost:3000/static/js/bundle.js:336577:29)
    at Switch (http://localhost:3000/static/js/bundle.js:336746:29)
    at Router (http://localhost:3000/static/js/bundle.js:336249:30)
    at HashRouter (http://localhost:3000/static/js/bundle.js:335801:35)
    at EnvironmentProvider (http://localhost:3000/static/js/bundle.js:28124:24)
    at ColorModeProvider (http://localhost:3000/static/js/bundle.js:16720:21)
    at ThemeProvider (http://localhost:3000/static/js/bundle.js:43708:64)
    at ThemeProvider (http://localhost:3000/static/js/bundle.js:32963:27)
    at http://localhost:3000/static/js/bundle.js:18725:23
    at ChakraProvider (http://localhost:3000/static/js/bundle.js:27498:24)
    at d (http://localhost:3000/static/js/bundle.js:355723:18)

Consider adding an error boundary to your tree to customize error handling behavior.
Visit https://reactjs.org/link/error-boundaries to learn more about error boundaries.
logCapturedError @ react-dom.development.js:20085
update.callback @ react-dom.development.js:20118
callCallback @ react-dom.development.js:12318
commitUpdateQueue @ react-dom.development.js:12339
commitLifeCycles @ react-dom.development.js:20736
commitLayoutEffects @ react-dom.development.js:23426
callCallback @ react-dom.development.js:3945
invokeGuardedCallbackDev @ react-dom.development.js:3994
invokeGuardedCallback @ react-dom.development.js:4056
commitRootImpl @ react-dom.development.js:23151
unstable_runWithPriority @ scheduler.development.js:468
runWithPriority$1 @ react-dom.development.js:11276
commitRoot @ react-dom.development.js:22990
performSyncWorkOnRoot @ react-dom.development.js:22329
scheduleUpdateOnFiber @ react-dom.development.js:21881
updateContainer @ react-dom.development.js:25482
(anonymous) @ react-dom.development.js:26021
unbatchedUpdates @ react-dom.development.js:22431
legacyRenderSubtreeIntoContainer @ react-dom.development.js:26020
render @ react-dom.development.js:26103
./src/index.tsx @ index.tsx:18
options.factory @ react refresh:6
__webpack_require__ @ bootstrap:24
(anonymous) @ startup:7
(anonymous) @ startup:7
react-dom.development.js:20349 Uncaught Error: A React component suspended while rendering, but no fallback UI was specified.

Add a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display.
    at throwException (react-dom.development.js:20349:1)
    at handleError (react-dom.development.js:22558:1)
    at renderRootSync (react-dom.development.js:22673:1)
    at performSyncWorkOnRoot (react-dom.development.js:22293:1)
    at scheduleUpdateOnFiber (react-dom.development.js:21881:1)
    at updateContainer (react-dom.development.js:25482:1)
    at react-dom.development.js:26021:1
    at unbatchedUpdates (react-dom.development.js:22431:1)
    at legacyRenderSubtreeIntoContainer (react-dom.development.js:26020:1)
    at Object.render (react-dom.development.js:26103:1)
throwException @ react-dom.development.js:20349
handleError @ react-dom.development.js:22558
renderRootSync @ react-dom.development.js:22673
performSyncWorkOnRoot @ react-dom.development.js:22293
scheduleUpdateOnFiber @ react-dom.development.js:21881
updateContainer @ react-dom.development.js:25482
(anonymous) @ react-dom.development.js:26021
unbatchedUpdates @ react-dom.development.js:22431
legacyRenderSubtreeIntoContainer @ react-dom.development.js:26020
render @ react-dom.development.js:26103
./src/index.tsx @ index.tsx:18
options.factory @ react refresh:6
__webpack_require__ @ bootstrap:24
(anonymous) @ startup:7
(anonymous) @ startup:7

```


on the sample app - it works well

