### PR TITLE
update use sdk

### DIFF
--- a/src/lib/components/AuthProvider/useSdk.ts
+++ b/src/lib/components/AuthProvider/useSdk.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import createSdk from '../../sdk';
 import { baseHeaders } from '../../constants';
+import createSdk from '../../sdk';
 
 type Config = Pick<
 	Parameters<typeof createSdk>[0],
@@ -24,4 +24,4 @@ export default ({
 			persistToken: true,
 			autoRefresh: true
 		});
-	}, [projectId, baseUrl]);
+	}, [projectId, baseUrl, sessionTokenViaCookie]);


### PR DESCRIPTION
something small that was missing, `useSdk` (an abstraction above `useMemo`) didn't consider `sessionTokenViaCookie`

eventually, we may have to add lints on this (or catch in tests or something. will open a dedicated issue)