### PR TITLE
add refresh token helper function to invalidate permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ DESCOPE_TELEMETRY_KEY=""
 
 You can also use the following functions to assist with various actions managing your JWT.
 
-`refresh(token = getRefreshToken())` - force a refresh on current session token using an existing valid refresh token.
-`getJwtRoles(token = getSessionToken(), tenant = '')` - get current (tenant if provided) roles from an existing session token.
-`getJwtPermissions(token = getSessionToken(), tenant = '')` - get current (tenant if provided) permissions from an existing session token.
+`refresh(token = getRefreshToken())` - Force a refresh on current session token using an existing valid refresh token.
+`getJwtRoles(token = getSessionToken(), tenant = '')` - Get current roles from an existing session token. Provide tenant id for specific tenant roles.
+`getJwtPermissions(token = getSessionToken(), tenant = '')` - Fet current permissions from an existing session token. Provide tenant id for specific tenant permissions.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ DESCOPE_STEP_UP_FLOW_ID=step-up
 DESCOPE_TELEMETRY_KEY=""
 ```
 
+## Helper Functions
+
+You can also use the following functions to assist with various actions managing your JWT.
+
+`refresh(token = getRefreshToken())` - force a refresh on current session token using an existing valid refresh token.
+`getJwtRoles(token = getSessionToken(), tenant = '')` - get current (tenant if provided) roles from an existing session token.
+`getJwtPermissions(token = getSessionToken(), tenant = '')` - get current (tenant if provided) permissions from an existing session token.
+
 ## Learn More
 
 To learn more please see the [Descope Documentation and API reference page](https://docs.descope.com/).

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export { default as useUser } from './hooks/useUser';
 export {
 	getJwtPermissions,
 	getJwtRoles,
-	refreshToken,
+	refresh,
 	getRefreshToken,
 	getSessionToken
 } from './sdk';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { default as useUser } from './hooks/useUser';
 export {
 	getJwtPermissions,
 	getJwtRoles,
+	refreshToken,
 	getRefreshToken,
 	getSessionToken
 } from './sdk';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -56,4 +56,13 @@ export const getJwtRoles = wrapInTry(
 		sdkInstance?.getJwtRoles(token, tenant)
 );
 
+export const refreshToken = (token?: string) => {
+	if (IS_BROWSER) {
+		return sdkInstance?.refresh(token);
+	}
+	// eslint-disable-next-line no-console
+	console.warn('Refresh token is not supported in SSR');
+	return null;
+};
+
 export default createSdkWrapper;

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -56,13 +56,6 @@ export const getJwtRoles = wrapInTry(
 		sdkInstance?.getJwtRoles(token, tenant)
 );
 
-export const refreshToken = (token?: string) => {
-	if (IS_BROWSER) {
-		return sdkInstance?.refresh(token);
-	}
-	// eslint-disable-next-line no-console
-	console.warn('Refresh token is not supported in SSR');
-	return null;
-};
+export const refreshToken = (token?: string) => sdkInstance?.refresh(token);
 
 export default createSdkWrapper;

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -56,6 +56,7 @@ export const getJwtRoles = wrapInTry(
 		sdkInstance?.getJwtRoles(token, tenant)
 );
 
-export const refreshToken = (token?: string) => sdkInstance?.refresh(token);
+export const refresh = (token = getRefreshToken()) =>
+	sdkInstance?.refresh(token);
 
 export default createSdkWrapper;

--- a/test/utilityFunctions.test.ts
+++ b/test/utilityFunctions.test.ts
@@ -1,4 +1,5 @@
-import createSdk, { refreshToken ,
+import createSdk, {
+	refreshToken,
 	getJwtPermissions,
 	getJwtRoles,
 	getRefreshToken,

--- a/test/utilityFunctions.test.ts
+++ b/test/utilityFunctions.test.ts
@@ -1,5 +1,5 @@
 import createSdk, {
-	refreshToken,
+	refresh,
 	getJwtPermissions,
 	getJwtRoles,
 	getRefreshToken,
@@ -81,7 +81,7 @@ describe('utility functions', () => {
 
 	it('should call refresh token with the session token', async () => {
 		(sdk.refresh as jest.Mock).getMockImplementation();
-		await refreshToken('test');
+		await refresh('test');
 		expect(sdk.refresh).toHaveBeenCalledWith('test');
 	});
 

--- a/test/utilityFunctions.test.ts
+++ b/test/utilityFunctions.test.ts
@@ -1,4 +1,4 @@
-import createSdk, {
+import createSdk, { refreshToken ,
 	getJwtPermissions,
 	getJwtRoles,
 	getRefreshToken,
@@ -9,7 +9,8 @@ jest.mock('@descope/web-js-sdk', () => () => ({
 	getSessionToken: jest.fn(),
 	getRefreshToken: jest.fn(),
 	getJwtPermissions: jest.fn(),
-	getJwtRoles: jest.fn()
+	getJwtRoles: jest.fn(),
+	refresh: jest.fn()
 }));
 
 const sdk = createSdk({ projectId: 'test' });
@@ -75,6 +76,12 @@ describe('utility functions', () => {
 			'Get refresh token is not supported in SSR'
 		);
 		expect(sdk.getRefreshToken).not.toHaveBeenCalled();
+	});
+
+	it('should call refresh token with the session token', async () => {
+		(sdk.refresh as jest.Mock).getMockImplementation();
+		await refreshToken('test');
+		expect(sdk.refresh).toHaveBeenCalledWith('test');
 	});
 
 	it('should call getJwtPermissions with the session token when not provided', () => {


### PR DESCRIPTION
## Related Issues

related https://github.com/descope/etc/issues/1974

## Description
add helper function to force refresh from the browser. This is useful for now whenever you invoke permission changes on current user outside of the (react-sdk such as REST API)

## Must

- [x] Tests
- [x] Documentation (if applicable)
