### PR TITLE
Fix set auth and user

### DIFF
--- a/src/components/Descope.tsx
+++ b/src/components/Descope.tsx
@@ -64,14 +64,10 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
 
 		useImperativeHandle(ref, () => innerRef);
 
-		const { projectId, baseUrl, setUser, setSession, sdk } =
-			React.useContext(Context);
+		const { projectId, baseUrl, sdk } = React.useContext(Context);
 
 		const handleSuccess = useCallback(
 			async (e: CustomEvent) => {
-				setUser(e.detail?.user);
-				const sessionJwt = e.detail?.sessionJwt;
-				setSession(sessionJwt);
 				// In order to make sure all the after-hooks are running with the success response
 				// we are generating a fake response with the success data and calling the http client after hook fn with it
 				await sdk.httpClient.hooks.afterRequest(
@@ -82,7 +78,7 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
 					onSuccess(e);
 				}
 			},
-			[setUser, setSession, onSuccess]
+			[onSuccess]
 		);
 
 		useEffect(() => {

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -2,7 +2,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import createSdk from '@descope/web-js-sdk';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../../examples/app/App';
@@ -45,35 +44,6 @@ describe('App', () => {
 		// reset mock functions that may be override
 		(onSessionTokenChange as jest.Mock).mockImplementation(() => () => {});
 		(onUserChange as jest.Mock).mockImplementation(() => () => {});
-	});
-
-	it('should get user on success', async () => {
-		renderWithRouter(
-			<AuthProvider projectId="p1">
-				<App />
-			</AuthProvider>
-		);
-
-		const loginButton = await screen.findByText('Login');
-
-		await userEvent.click(loginButton);
-
-		await waitFor(() => {
-			expect(document.querySelector('descope-wc')).toBeInTheDocument();
-		});
-
-		// mock success
-		fireEvent(
-			document.querySelector('descope-wc'),
-			new CustomEvent('success', {
-				detail: { user: { name: 'user1' }, sessionJwt: 'session1' }
-			})
-		);
-
-		// ensure user details are shown
-		await waitFor(() =>
-			expect(document.querySelector('.username')).toHaveTextContent(/user1/)
-		);
 	});
 
 	it('should subscribe to user and session token', async () => {
@@ -128,27 +98,18 @@ describe('App', () => {
 	});
 
 	it('should render logout button and and call sdk logout', async () => {
-		const { container } = renderWithRouter(
+		(onSessionTokenChange as jest.Mock).mockImplementation((cb) => {
+			cb('token1');
+			return () => {};
+		});
+		(onUserChange as jest.Mock).mockImplementation((cb) => {
+			cb({ name: 'user1' });
+			return () => {};
+		});
+		renderWithRouter(
 			<AuthProvider projectId="p1">
 				<App />
 			</AuthProvider>
-		);
-		const loginButton = await screen.findByText('Login');
-		fireEvent.click(loginButton);
-
-		// eslint-disable-next-line testing-library/no-container
-		await waitFor(() =>
-			// eslint-disable-next-line testing-library/no-container
-			expect(container.querySelector('descope-wc')).toBeInTheDocument()
-		);
-
-		// mock success
-		fireEvent(
-			// eslint-disable-next-line testing-library/no-container
-			container.querySelector('descope-wc'),
-			new CustomEvent('success', {
-				detail: { user: { name: 'user1' }, sessionJwt: 'session1' }
-			})
 		);
 
 		// logout


### PR DESCRIPTION
## Description
Fix an issue when a completed flow does not return any authentication info

noting that the update happens in the `afterRequest` in case the auth info is returned 


