### PR TITLE
Fix refresh loop when useSession called multiple times

### DIFF
--- a/src/components/AuthProvider/AuthProvider.tsx
+++ b/src/components/AuthProvider/AuthProvider.tsx
@@ -1,4 +1,11 @@
-import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+	FC,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState
+} from 'react';
 import Context from '../../hooks/Context';
 import { IContext, User } from '../../types';
 import { withValidation } from '../../utils';
@@ -42,7 +49,13 @@ const AuthProvider: FC<IAuthProviderProps> = ({
 		return undefined;
 	}, [sdk]);
 
+	const isSessionFetched = useRef(false);
+
 	const fetchSession = useCallback(() => {
+		// We want that the session will fetched only once
+		if (isSessionFetched.current) return;
+		isSessionFetched.current = true;
+
 		setIsSessionLoading(true);
 		withValidation(sdk?.refresh)().then(() => {
 			setIsSessionLoading(false);

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -35,7 +35,7 @@ jest.mock('@descope/web-js-sdk', () => {
 const renderWithRouter = (ui: React.ReactElement) =>
 	render(<MemoryRouter>{ui}</MemoryRouter>);
 
-const { logout, onSessionTokenChange, onUserChange } = createSdk({
+const { logout, onSessionTokenChange, onUserChange, refresh } = createSdk({
 	projectId: ''
 });
 
@@ -118,5 +118,20 @@ describe('App', () => {
 
 		// ensure logout called
 		expect(logout).toBeCalled();
+	});
+
+	it('should call refresh only once when useSession used twice', async () => {
+		// rendering App twice which uses useSession
+		renderWithRouter(
+			<AuthProvider projectId="p1">
+				<>
+					<App />
+					<App />
+				</>
+			</AuthProvider>
+		);
+
+		// ensure refresh called only once
+		expect(refresh).toBeCalledTimes(1);
 	});
 });

--- a/test/hooks/useAuth.test.tsx
+++ b/test/hooks/useAuth.test.tsx
@@ -112,12 +112,4 @@ describe('hooks', () => {
 		expect(result.current.isAuthenticated).toEqual(false);
 		expect(result.current.sessionToken).toEqual(undefined);
 	});
-
-	it('test1111', () => {
-		const { result } = renderHook(() => useSession(), {
-			wrapper: authProviderWrapper('project1')
-		});
-		expect(result.current.isAuthenticated).toEqual(false);
-		expect(result.current.sessionToken).toEqual(undefined);
-	});
 });

--- a/test/hooks/useAuth.test.tsx
+++ b/test/hooks/useAuth.test.tsx
@@ -112,4 +112,12 @@ describe('hooks', () => {
 		expect(result.current.isAuthenticated).toEqual(false);
 		expect(result.current.sessionToken).toEqual(undefined);
 	});
+
+	it('test1111', () => {
+		const { result } = renderHook(() => useSession(), {
+			wrapper: authProviderWrapper('project1')
+		});
+		expect(result.current.isAuthenticated).toEqual(false);
+		expect(result.current.sessionToken).toEqual(undefined);
+	});
 });


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/2815

## Description
trigger refresh only once

the fetchSession will be called for each `useSession` but will not trigger refresh 