### PR TITLE
Handle default props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -101,6 +101,7 @@
 		"import/no-dynamic-require": 2,
 		"import/no-self-import": 2,
 		"import/no-useless-path-segments": 2,
+		"react/require-default-props": [2, { "functions": "defaultArguments" }],
 		"import/no-extraneous-dependencies": [
 			2,
 			{

--- a/src/components/AuthProvider/AuthProvider.tsx
+++ b/src/components/AuthProvider/AuthProvider.tsx
@@ -24,9 +24,9 @@ interface IAuthProviderProps {
 
 const AuthProvider: FC<IAuthProviderProps> = ({
 	projectId,
-	baseUrl,
-	sessionTokenViaCookie,
-	children
+	baseUrl = '',
+	sessionTokenViaCookie = false,
+	children = undefined
 }) => {
 	const [user, setUser] = useState<User>();
 	const [session, setSession] = useState<string>();
@@ -100,12 +100,6 @@ const AuthProvider: FC<IAuthProviderProps> = ({
 		]
 	);
 	return <Context.Provider value={value}>{children}</Context.Provider>;
-};
-
-AuthProvider.defaultProps = {
-	baseUrl: '',
-	children: undefined,
-	sessionTokenViaCookie: false
 };
 
 export default AuthProvider;


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/3442


## Description
- remove defaultProps
- align the rule to use `defaultArguments` according to [rule docs](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md) 