### PR TITLE
Override web component sdk configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1959,9 +1959,9 @@
 			}
 		},
 		"node_modules/@descope/core-js-sdk": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.8.2.tgz",
-			"integrity": "sha512-73YVMjF3DouBz0hLbLsAPGVyYvBlm0AcRQbLj9YZSURlGI0yiROOTfVU2YTqauHCTnXjJgUJeTB1FALRk5SJVg==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.9.1.tgz",
+			"integrity": "sha512-pnj390un0HbdIFDsVeHHWmwjsBx0sJOwrrsoyZEi4W7jBBUmOfKCq1Rs4oNQgjuklWHmjqQKFLIm+rafOH8z3w==",
 			"dependencies": {
 				"jwt-decode": "3.1.2",
 				"lodash.get": "4.4.2"
@@ -2025,20 +2025,20 @@
 			}
 		},
 		"node_modules/@descope/web-component": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.3.tgz",
-			"integrity": "sha512-Mt782epOg/GVCGXXujjbtMEZPBLs09thKRMiBd7AYldTb9NyPb+/i8m33pwL0hVh6yLPLIWlPuJ90KlP8lC/Iw==",
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.6.tgz",
+			"integrity": "sha512-sjRhvfnhv1Wph4jZmiA8U5A1KZWkOXn82TeYDE0Mo/qavY+McA79VShLRoQm5kGWH4b/pNWcMlXtb1ajJhdBNg==",
 			"dependencies": {
-				"@descope/web-js-sdk": "1.9.2",
+				"@descope/web-js-sdk": "1.9.5",
 				"tslib": "2.6.2"
 			}
 		},
 		"node_modules/@descope/web-js-sdk": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.0.tgz",
-			"integrity": "sha512-ESBLVf/Edmo2joUATy16mnXXmJ/MjyPQg+LuvMNN8Ngpnvli23C9eHo3Z+XxSkflzcV3KhtpOCNyxmbjRR2u2g==",
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.5.tgz",
+			"integrity": "sha512-4i/1iHDC/B6U97Jyh9n6lFFnqi2apEVR8P9zkUToLn4luBlX/dX18QTlylZIjXaVtW29NkkRnpsoNGDwqsYLuQ==",
 			"dependencies": {
-				"@descope/core-js-sdk": "2.8.0",
+				"@descope/core-js-sdk": "2.9.1",
 				"@fingerprintjs/fingerprintjs-pro": "3.8.5",
 				"js-cookie": "3.0.5",
 				"tslib": "2.6.2"
@@ -16665,9 +16665,9 @@
 			}
 		},
 		"@descope/core-js-sdk": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.8.0.tgz",
-			"integrity": "sha512-2MTgEInuLGSPsfnnMxaEInp7JyQjHhHU++TEoLhaoX0jmDT2tWrCLh6Lgyv5sSfST957T6CPxBSjjG9ItwTRKA==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.9.1.tgz",
+			"integrity": "sha512-pnj390un0HbdIFDsVeHHWmwjsBx0sJOwrrsoyZEi4W7jBBUmOfKCq1Rs4oNQgjuklWHmjqQKFLIm+rafOH8z3w==",
 			"requires": {
 				"jwt-decode": "3.1.2",
 				"lodash.get": "4.4.2"
@@ -16721,20 +16721,20 @@
 			}
 		},
 		"@descope/web-component": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.0.tgz",
-			"integrity": "sha512-nMfCL6nixPHy9CKGbVtiKuG3t46J0oH5/bXG4FhERoXm20Ind/AkVHoSv+Smg0FRJIfJ/LquYS+SXP2M+B9zsA==",
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.6.tgz",
+			"integrity": "sha512-sjRhvfnhv1Wph4jZmiA8U5A1KZWkOXn82TeYDE0Mo/qavY+McA79VShLRoQm5kGWH4b/pNWcMlXtb1ajJhdBNg==",
 			"requires": {
-				"@descope/web-js-sdk": "1.9.0",
+				"@descope/web-js-sdk": "1.9.5",
 				"tslib": "2.6.2"
 			}
 		},
 		"@descope/web-js-sdk": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.0.tgz",
-			"integrity": "sha512-ESBLVf/Edmo2joUATy16mnXXmJ/MjyPQg+LuvMNN8Ngpnvli23C9eHo3Z+XxSkflzcV3KhtpOCNyxmbjRR2u2g==",
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.5.tgz",
+			"integrity": "sha512-4i/1iHDC/B6U97Jyh9n6lFFnqi2apEVR8P9zkUToLn4luBlX/dX18QTlylZIjXaVtW29NkkRnpsoNGDwqsYLuQ==",
 			"requires": {
-				"@descope/core-js-sdk": "2.8.0",
+				"@descope/core-js-sdk": "2.9.1",
 				"@fingerprintjs/fingerprintjs-pro": "3.8.5",
 				"js-cookie": "3.0.5",
 				"tslib": "2.6.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.0.5",
 			"license": "MIT",
 			"dependencies": {
-				"@descope/web-component": "3.7.0"
+				"@descope/web-component": "3.7.6"
 			},
 			"devDependencies": {
 				"@babel/core": "7.23.0",
@@ -1958,29 +1958,29 @@
 			}
 		},
 		"node_modules/@descope/core-js-sdk": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.8.0.tgz",
-			"integrity": "sha512-2MTgEInuLGSPsfnnMxaEInp7JyQjHhHU++TEoLhaoX0jmDT2tWrCLh6Lgyv5sSfST957T6CPxBSjjG9ItwTRKA==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.9.1.tgz",
+			"integrity": "sha512-pnj390un0HbdIFDsVeHHWmwjsBx0sJOwrrsoyZEi4W7jBBUmOfKCq1Rs4oNQgjuklWHmjqQKFLIm+rafOH8z3w==",
 			"dependencies": {
 				"jwt-decode": "3.1.2",
 				"lodash.get": "4.4.2"
 			}
 		},
 		"node_modules/@descope/web-component": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.0.tgz",
-			"integrity": "sha512-nMfCL6nixPHy9CKGbVtiKuG3t46J0oH5/bXG4FhERoXm20Ind/AkVHoSv+Smg0FRJIfJ/LquYS+SXP2M+B9zsA==",
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.6.tgz",
+			"integrity": "sha512-sjRhvfnhv1Wph4jZmiA8U5A1KZWkOXn82TeYDE0Mo/qavY+McA79VShLRoQm5kGWH4b/pNWcMlXtb1ajJhdBNg==",
 			"dependencies": {
-				"@descope/web-js-sdk": "1.9.0",
+				"@descope/web-js-sdk": "1.9.5",
 				"tslib": "2.6.2"
 			}
 		},
 		"node_modules/@descope/web-js-sdk": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.0.tgz",
-			"integrity": "sha512-ESBLVf/Edmo2joUATy16mnXXmJ/MjyPQg+LuvMNN8Ngpnvli23C9eHo3Z+XxSkflzcV3KhtpOCNyxmbjRR2u2g==",
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.5.tgz",
+			"integrity": "sha512-4i/1iHDC/B6U97Jyh9n6lFFnqi2apEVR8P9zkUToLn4luBlX/dX18QTlylZIjXaVtW29NkkRnpsoNGDwqsYLuQ==",
 			"dependencies": {
-				"@descope/core-js-sdk": "2.8.0",
+				"@descope/core-js-sdk": "2.9.1",
 				"@fingerprintjs/fingerprintjs-pro": "3.8.5",
 				"js-cookie": "3.0.5",
 				"tslib": "2.6.2"
@@ -16580,29 +16580,29 @@
 			}
 		},
 		"@descope/core-js-sdk": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.8.0.tgz",
-			"integrity": "sha512-2MTgEInuLGSPsfnnMxaEInp7JyQjHhHU++TEoLhaoX0jmDT2tWrCLh6Lgyv5sSfST957T6CPxBSjjG9ItwTRKA==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.9.1.tgz",
+			"integrity": "sha512-pnj390un0HbdIFDsVeHHWmwjsBx0sJOwrrsoyZEi4W7jBBUmOfKCq1Rs4oNQgjuklWHmjqQKFLIm+rafOH8z3w==",
 			"requires": {
 				"jwt-decode": "3.1.2",
 				"lodash.get": "4.4.2"
 			}
 		},
 		"@descope/web-component": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.0.tgz",
-			"integrity": "sha512-nMfCL6nixPHy9CKGbVtiKuG3t46J0oH5/bXG4FhERoXm20Ind/AkVHoSv+Smg0FRJIfJ/LquYS+SXP2M+B9zsA==",
+			"version": "3.7.6",
+			"resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.7.6.tgz",
+			"integrity": "sha512-sjRhvfnhv1Wph4jZmiA8U5A1KZWkOXn82TeYDE0Mo/qavY+McA79VShLRoQm5kGWH4b/pNWcMlXtb1ajJhdBNg==",
 			"requires": {
-				"@descope/web-js-sdk": "1.9.0",
+				"@descope/web-js-sdk": "1.9.5",
 				"tslib": "2.6.2"
 			}
 		},
 		"@descope/web-js-sdk": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.0.tgz",
-			"integrity": "sha512-ESBLVf/Edmo2joUATy16mnXXmJ/MjyPQg+LuvMNN8Ngpnvli23C9eHo3Z+XxSkflzcV3KhtpOCNyxmbjRR2u2g==",
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.9.5.tgz",
+			"integrity": "sha512-4i/1iHDC/B6U97Jyh9n6lFFnqi2apEVR8P9zkUToLn4luBlX/dX18QTlylZIjXaVtW29NkkRnpsoNGDwqsYLuQ==",
 			"requires": {
-				"@descope/core-js-sdk": "2.8.0",
+				"@descope/core-js-sdk": "2.9.1",
 				"@fingerprintjs/fingerprintjs-pro": "3.8.5",
 				"js-cookie": "3.0.5",
 				"tslib": "2.6.2"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		]
 	},
 	"dependencies": {
-		"@descope/web-component": "3.7.0"
+		"@descope/web-component": "3.7.6"
 	},
 	"devDependencies": {
 		"@babel/core": "7.23.0",

--- a/src/components/Descope.tsx
+++ b/src/components/Descope.tsx
@@ -15,19 +15,19 @@ import { getGlobalSdk } from '../sdk';
 // web-component code uses browser API, but can be used in SSR apps, hence the lazy loading
 const DescopeWC = lazy(async () => {
 	const module = await import('@descope/web-component');
-	// we want to override the web-component base headers so we can tell that is was used via the React SDK
 	module.default.sdkConfigOverrides = {
+		// Overrides the web-component's base headers to indicate usage via the React SDK
 		baseHeaders,
-		// the inner web-component will not persist the tokens
-		// So the global SDK hooks will handle the tokens according to the SDK configuration
+		// Disables token persistence within the web-component to delegate token management
+		// to the global SDK hooks. This ensures token handling aligns with the SDK's configuration,
+		// and web-component requests leverage the global SDK's beforeRequest hooks for consistency
 		persistTokens: false,
 		hooks: {
 			get beforeRequest() {
-				// Done we can use the same hooks in the web-component according to the SDK configuration
+				// Retrieves the beforeRequest hook from the global SDK, which is initialized
+				// within the AuthProvider using the desired configuration. This approach ensures
+				// the web-component utilizes the same beforeRequest hooks as the global SDK
 				return getGlobalSdk().httpClient.hooks.beforeRequest;
-			},
-			set beforeRequest(_) {
-				/* empty */
 			}
 		}
 	};

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,7 +3,7 @@ import { IS_BROWSER } from './constants';
 import { wrapInTry } from './utils';
 
 type Sdk = ReturnType<typeof createSdkWrapper>;
-let sdkInstance: Sdk;
+let globalSdk: Sdk;
 
 const createSdkWrapper = <P extends Parameters<typeof createSdk>[0]>(
 	config: P
@@ -13,7 +13,7 @@ const createSdkWrapper = <P extends Parameters<typeof createSdk>[0]>(
 		persistTokens: IS_BROWSER as true,
 		autoRefresh: IS_BROWSER as true
 	});
-	sdkInstance = sdk;
+	globalSdk = sdk;
 
 	return sdk;
 };
@@ -25,11 +25,11 @@ const createSdkWrapper = <P extends Parameters<typeof createSdk>[0]>(
  * and we are creating a temp instance in order to export the getSessionToken
  * even before the SDK was init
  */
-sdkInstance = createSdkWrapper({ projectId: 'temp pid' });
+globalSdk = createSdkWrapper({ projectId: 'temp pid' });
 
 export const getSessionToken = () => {
 	if (IS_BROWSER) {
-		return sdkInstance?.getSessionToken();
+		return globalSdk?.getSessionToken();
 	}
 
 	// eslint-disable-next-line no-console
@@ -39,7 +39,7 @@ export const getSessionToken = () => {
 
 export const getRefreshToken = () => {
 	if (IS_BROWSER) {
-		return sdkInstance?.getRefreshToken();
+		return globalSdk?.getRefreshToken();
 	}
 	// eslint-disable-next-line no-console
 	console.warn('Get refresh token is not supported in SSR');
@@ -48,15 +48,16 @@ export const getRefreshToken = () => {
 
 export const getJwtPermissions = wrapInTry(
 	(token = getSessionToken(), tenant?: string) =>
-		sdkInstance?.getJwtPermissions(token, tenant)
+		globalSdk?.getJwtPermissions(token, tenant)
 );
 
 export const getJwtRoles = wrapInTry(
 	(token = getSessionToken(), tenant?: string) =>
-		sdkInstance?.getJwtRoles(token, tenant)
+		globalSdk?.getJwtRoles(token, tenant)
 );
 
-export const refresh = (token = getRefreshToken()) =>
-	sdkInstance?.refresh(token);
+export const refresh = (token = getRefreshToken()) => globalSdk?.refresh(token);
+
+export const getGlobalSdk = () => globalSdk;
 
 export default createSdkWrapper;

--- a/test/components/Descope.test.tsx
+++ b/test/components/Descope.test.tsx
@@ -3,6 +3,8 @@
 import createSdk from '@descope/web-js-sdk';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
+// eslint-disable-next-line import/no-named-default
+import { default as DescopeWC } from '@descope/web-component';
 import AuthProvider from '../../src/components/AuthProvider';
 import Descope from '../../src/components/Descope';
 
@@ -24,7 +26,8 @@ jest.mock('@descope/web-js-sdk', () => {
 		refresh: jest.fn(),
 		httpClient: {
 			hooks: {
-				afterRequest: jest.fn()
+				beforeRequest: jest.fn().mockName('before-request-hook'),
+				afterRequest: jest.fn().mockName('after-request-hook')
 			}
 		}
 	};
@@ -43,6 +46,32 @@ const renderWithProvider = (
 	);
 
 describe('Descope', () => {
+	it('Should init sdk config', async () => {
+		renderWithProvider(<Descope flowId="flow1" />, 'proj1', 'url1');
+
+		await waitFor(() => {
+			expect(document.querySelector('descope-wc')).toBeInTheDocument();
+		});
+
+		// ensure the sdk was created with the correct config
+		expect(DescopeWC.sdkConfigOverrides).toEqual({
+			baseHeaders: {
+				'x-descope-sdk-name': 'react',
+				'x-descope-sdk-version': 'one.two.three'
+			},
+			persistTokens: false,
+			hooks: {
+				beforeRequest: expect.any(Function)
+			}
+		});
+
+		// ensure beforeRequest hook was set with the correct value
+		const {beforeRequest} = DescopeWC.sdkConfigOverrides.hooks;
+		expect((beforeRequest as jest.Mock).getMockName()).toBe(
+			'before-request-hook'
+		);
+	});
+
 	it('should render the WC with the correct props', async () => {
 		renderWithProvider(<Descope flowId="flow1" />, 'proj1', 'url1');
 

--- a/test/components/Descope.test.tsx
+++ b/test/components/Descope.test.tsx
@@ -66,7 +66,7 @@ describe('Descope', () => {
 		});
 
 		// ensure beforeRequest hook was set with the correct value
-		const {beforeRequest} = DescopeWC.sdkConfigOverrides.hooks;
+		const { beforeRequest } = DescopeWC.sdkConfigOverrides.hooks;
 		expect((beforeRequest as jest.Mock).getMockName()).toBe(
 			'before-request-hook'
 		);


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/5319

## Related PRs

https://github.com/descope/descope-js/pull/356


## Description
Override web component sdk configs so that the hooks running before will run in the same manner