### PR TITLE
fix logger warning

### DIFF
--- a/test/components/Descope.test.tsx
+++ b/test/components/Descope.test.tsx
@@ -139,7 +139,12 @@ describe('Descope', () => {
 	});
 
 	it('should pass logger and update web components logger', async () => {
-		const logger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+		const logger = {
+			info: jest.fn(),
+			error: jest.fn(),
+			warn: jest.fn(),
+			debug: jest.fn()
+		};
 		renderWithProvider(<Descope flowId="flow-1" logger={logger} />);
 		await waitFor(() => {
 			expect(document.querySelector('descope-wc')).toBeInTheDocument();


### PR DESCRIPTION


## Description
fix the following warning when building the sdk:
![image](https://github.com/descope/react-sdk/assets/10514677/bb00ceda-faed-4da2-8270-960eeca16736)
